### PR TITLE
Render completed tasks as twinkling stars in Saturn view (#8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit-task-control",
   "type": "module",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit-task-control",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit-task-control",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit-task-control",
   "type": "module",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -13,10 +13,28 @@ const taskInput = document.getElementById('task-input');
 const taskBoxEdit = document.getElementById('task-box-edit');
 let suppressInputBlur = false;
 
+// Find the next index (dir=+1 forward, dir=-1 backward) that satisfies filter.
+// Returns `from` unchanged if no match exists.
+function nextIdx(from, dir, filter) {
+  const n = state.tasks.length;
+  if (!n) return from;
+  let idx = (from + dir + n) % n;
+  for (let steps = 0; steps < n; steps++) {
+    if (filter(state.tasks[idx])) return idx;
+    idx = (idx + dir + n) % n;
+  }
+  return from;
+}
+
+function firstActiveIdx() {
+  const i = state.tasks.findIndex(t => !t.done);
+  return i >= 0 ? i : 0;
+}
+
 function goToRing() {
   if (!state.tasks.length) return;
   suppressInputBlur = true; taskInput.blur(); suppressInputBlur = false;
-  if (state.selectedIdx < 0) state.selectedIdx = 0;
+  if (state.selectedIdx < 0) state.selectedIdx = firstActiveIdx();
   setMode('ring');
 }
 
@@ -93,13 +111,13 @@ document.addEventListener('keydown', e => {
       break;
     case 'n': case 'N': e.preventDefault(); goToInput(); break;
 
-    // ── j: next task (saturn) / down (list) ──────────────────────────────────
+    // ── j: next active task (saturn) / down (list) ───────────────────────────
     case 'j': {
       e.preventDefault();
       if (!state.tasks.length) break;
       if (isSaturn) {
-        if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = 0; setMode('ring'); break; }
-        state.selectedIdx = (state.selectedIdx + 1) % state.tasks.length;
+        if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = firstActiveIdx(); setMode('ring'); break; }
+        state.selectedIdx = nextIdx(state.selectedIdx, 1, t => !t.done);
         state.selectedSubIdx = -1;
       } else {
         if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = 0; state.selectedSubIdx = -1; setMode('ring'); moveHighlight(); break; }
@@ -111,13 +129,13 @@ document.addEventListener('keydown', e => {
       break;
     }
 
-    // ── k: prev task (saturn) / up (list) ────────────────────────────────────
+    // ── k: prev active task (saturn) / up (list) ─────────────────────────────
     case 'k': {
       e.preventDefault();
       if (!state.tasks.length) break;
       if (isSaturn) {
-        if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = 0; setMode('ring'); break; }
-        state.selectedIdx = (state.selectedIdx - 1 + state.tasks.length) % state.tasks.length;
+        if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = firstActiveIdx(); setMode('ring'); break; }
+        state.selectedIdx = nextIdx(state.selectedIdx, -1, t => !t.done);
         state.selectedSubIdx = -1;
       } else {
         if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = 0; state.selectedSubIdx = -1; setMode('ring'); moveHighlight(); break; }
@@ -128,23 +146,34 @@ document.addEventListener('keydown', e => {
       break;
     }
 
-    // ── Arrow Left: next task (saturn, flipped) ───────────────────────────────
+    // ── Arrow Left: next active task (saturn, flipped) ───────────────────────
     case 'ArrowLeft': {
       e.preventDefault();
       if (!state.tasks.length || !isSaturn) break;
-      if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = 0; setMode('ring'); break; }
-      state.selectedIdx = (state.selectedIdx + 1) % state.tasks.length;
+      if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = firstActiveIdx(); setMode('ring'); break; }
+      state.selectedIdx = nextIdx(state.selectedIdx, 1, t => !t.done);
       state.selectedSubIdx = -1;
       break;
     }
 
-    // ── Arrow Right: prev task (saturn, flipped) ──────────────────────────────
+    // ── Arrow Right: prev active task (saturn, flipped) ───────────────────────
     case 'ArrowRight': {
       e.preventDefault();
       if (!state.tasks.length || !isSaturn) break;
-      if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = 0; setMode('ring'); break; }
-      state.selectedIdx = (state.selectedIdx - 1 + state.tasks.length) % state.tasks.length;
+      if (state.mode !== 'ring') { if (state.selectedIdx < 0) state.selectedIdx = firstActiveIdx(); setMode('ring'); break; }
+      state.selectedIdx = nextIdx(state.selectedIdx, -1, t => !t.done);
       state.selectedSubIdx = -1;
+      break;
+    }
+
+    // ── C: cycle through completed stars (saturn only) ────────────────────────
+    case 'c': case 'C': {
+      if (!isSaturn) break;
+      e.preventDefault();
+      if (!state.tasks.some(t => t.done)) break;
+      state.selectedIdx = nextIdx(state.selectedIdx, 1, t => t.done);
+      state.selectedSubIdx = -1;
+      if (state.mode !== 'ring') setMode('ring');
       break;
     }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -34,7 +34,7 @@ function firstActiveIdx() {
 function goToRing() {
   if (!state.tasks.length) return;
   suppressInputBlur = true; taskInput.blur(); suppressInputBlur = false;
-  if (state.selectedIdx < 0) state.selectedIdx = firstActiveIdx();
+  if (state.selectedIdx < 0 || state.tasks[state.selectedIdx]?.done) state.selectedIdx = firstActiveIdx();
   setMode('ring');
 }
 

--- a/src/js/orbitRenderer.js
+++ b/src/js/orbitRenderer.js
@@ -74,7 +74,56 @@ export function ellipsePoint(angle, rx = RING_RX, ry = RING_RY) {
 }
 
 function getRotationForSelected(idx) {
-  return state.tasks.length === 0 ? 0 : SELECTED_ANGLE - (idx / state.tasks.length) * Math.PI * 2;
+  if (state.tasks.length === 0) return 0;
+  const task = state.tasks[idx];
+  if (!task || task.done) return ringRotation; // completed tasks leave the ring; don't snap
+  return SELECTED_ANGLE - (idx / state.tasks.length) * Math.PI * 2;
+}
+
+// ─── COMPLETED TASK STARS ─────────────────────────────────────────────────────
+function starPos(id) {
+  let h = ((id * 1664525 + 1013904223) >>> 0);
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const r1 = (h % 65536) / 65536;
+    h = ((h * 1664525 + 1013904223) >>> 0);
+    const r2 = (h % 65536) / 65536;
+    h = ((h * 1664525 + 1013904223) >>> 0);
+    const x = 30 + r1 * 640;
+    const y = 25 + r2 * 410;
+    const dx = (x - CX) / 260, dy = (y - CY) / 125;
+    if (dx * dx + dy * dy > 1) return { x, y };
+  }
+  return { x: 40, y: 40 };
+}
+
+function drawCompletedStars(t) {
+  const group = document.getElementById('completed-stars');
+  group.innerHTML = '';
+  const mk = (tag, attrs) => { const e = document.createElementNS('http://www.w3.org/2000/svg', tag); Object.entries(attrs).forEach(([k, v]) => e.setAttribute(k, v)); return e; };
+
+  state.tasks.forEach((task, i) => {
+    if (!task.done) return;
+    const { x, y } = starPos(task.id);
+    const isSel = i === state.selectedIdx && state.mode === 'ring';
+    const twinkle = 0.55 + 0.45 * Math.sin(t * 1.8 + (task.id % 100) * 0.37);
+
+    // Outer glow
+    group.appendChild(mk('circle', { cx: x, cy: y, r: isSel ? 18 : 9, fill: `rgba(0,255,204,${((isSel ? 0.22 : 0.07) * twinkle).toFixed(3)})`, filter: 'url(#taskGlow)' }));
+
+    // 4-pointed star rays (+ and ×)
+    const rl = isSel ? 11 : 6.5;
+    [[1, 0], [0, 1], [0.707, 0.707], [-0.707, 0.707]].forEach(([dx, dy]) => {
+      group.appendChild(mk('line', {
+        x1: (x - dx * rl).toFixed(1), y1: (y - dy * rl).toFixed(1),
+        x2: (x + dx * rl).toFixed(1), y2: (y + dy * rl).toFixed(1),
+        stroke: '#00ffcc', 'stroke-width': isSel ? 1.3 : 0.8,
+        opacity: ((isSel ? 0.95 : 0.5) * twinkle).toFixed(3),
+      }));
+    });
+
+    // Core
+    group.appendChild(mk('circle', { cx: x, cy: y, r: isSel ? 3.5 : 2.2, fill: '#00ffcc', opacity: (isSel ? 1 : (0.8 * twinkle)).toFixed(3) }));
+  });
 }
 
 function drawRing(rot) {
@@ -119,6 +168,7 @@ function drawTasks(rot) {
   const mk = (tag, attrs) => { const e = document.createElementNS('http://www.w3.org/2000/svg', tag); Object.entries(attrs).forEach(([k, v]) => e.setAttribute(k, v)); return e; };
 
   state.tasks.forEach((task, i) => {
+    if (task.done) return; // completed tasks leave the ring and become stars
     const ring = STATUS_RINGS[task.status] || STATUS_RINGS.todo;
     const angle = (i / state.tasks.length) * Math.PI * 2 + rot;
     const pt = ellipsePoint(angle, ring.rx, ring.ry);
@@ -199,7 +249,7 @@ export function startAnimLoop(onFrame) {
     if (newTaskAnimating) { newTaskAnimating.progress += dt / 700; if (newTaskAnimating.progress >= 1) newTaskAnimating = null; }
     const es = document.getElementById('empty-svg-state');
     if (es) es.style.display = state.tasks.length === 0 ? 'block' : 'none';
-    if (state.currentView === 'saturn') { drawRing(ringRotation); drawTasks(ringRotation); }
+    if (state.currentView === 'saturn') { drawRing(ringRotation); drawCompletedStars(subTaskRotation); drawTasks(ringRotation); }
     onFrame();
     requestAnimationFrame(animLoop);
   }

--- a/src/js/orbitRenderer.js
+++ b/src/js/orbitRenderer.js
@@ -67,6 +67,29 @@ export function setNewTaskAnimating(val) {
   newTaskAnimating = val;
 }
 
+// ─── COMPLETION ANIMATIONS ────────────────────────────────────────────────────
+export let completionAnimations = [];
+
+export function addCompletionAnimation(taskIdx, n) {
+  const task = state.tasks[taskIdx];
+  if (!task) return;
+  const ring = STATUS_RINGS[task.status] || STATUS_RINGS.todo;
+  completionAnimations.push({
+    taskId: task.id,
+    angleOffset: (taskIdx / n) * Math.PI * 2,
+    ringRx: ring.rx,
+    ringRy: ring.ry,
+    color: TASK_COLORS[taskIdx % TASK_COLORS.length],
+    targetPos: starPos(task.id),
+    progress: 0,
+    ringExitPt: null,
+  });
+}
+
+export function cancelCompletionAnimation(taskId) {
+  completionAnimations = completionAnimations.filter(a => a.taskId !== taskId);
+}
+
 export function ellipsePoint(angle, rx = RING_RX, ry = RING_RY) {
   const x = CX + rx * Math.cos(angle), y = CY + ry * Math.sin(angle);
   const dx = x - CX, dy = y - CY;
@@ -103,6 +126,7 @@ function drawCompletedStars(t) {
 
   state.tasks.forEach((task, i) => {
     if (!task.done) return;
+    if (completionAnimations.some(a => a.taskId === task.id)) return; // still animating in
     const { x, y } = starPos(task.id);
     const isSel = i === state.selectedIdx && state.mode === 'ring';
     const twinkle = 0.55 + 0.45 * Math.sin(t * 1.8 + (task.id % 100) * 0.37);
@@ -123,6 +147,82 @@ function drawCompletedStars(t) {
 
     // Core
     group.appendChild(mk('circle', { cx: x, cy: y, r: isSel ? 3.5 : 2.2, fill: '#00ffcc', opacity: (isSel ? 1 : (0.8 * twinkle)).toFixed(3) }));
+  });
+}
+
+function drawCompletionAnimations() {
+  if (!completionAnimations.length) return;
+  const front = document.getElementById('tasks-front');
+  const mk = (tag, attrs) => { const e = document.createElementNS('http://www.w3.org/2000/svg', tag); Object.entries(attrs).forEach(([k, v]) => e.setAttribute(k, v)); return e; };
+
+  completionAnimations.forEach(anim => {
+    const { progress, angleOffset, ringRx, ringRy, color, targetPos } = anim;
+
+    if (progress < 0.5) {
+      // ── Phase 1: accelerating orbit ──────────────────────────────────────────
+      const t = progress / 0.5;
+      const extraAngle = t * t * Math.PI * 3; // quadratic ease-in → ~1.5 extra orbits
+      const angle = angleOffset + ringRotation + extraAngle;
+      const pt = ellipsePoint(angle, ringRx, ringRy);
+
+      // Speed trail — ghost copies at earlier angles, fading out
+      for (let i = 3; i >= 1; i--) {
+        const ta = angle - i * 0.14 * (1 + t * 4);
+        const tp = ellipsePoint(ta, ringRx, ringRy);
+        front.appendChild(mk('circle', { cx: tp.x.toFixed(1), cy: tp.y.toFixed(1), r: 9 - i * 1.5, fill: color.fill, opacity: ((0.28 - i * 0.06) * t).toFixed(3) }));
+      }
+      // Growing glow as it accelerates
+      front.appendChild(mk('circle', { cx: pt.x.toFixed(1), cy: pt.y.toFixed(1), r: (20 + t * 8).toFixed(1), fill: color.glow.replace('0.8', (0.1 + t * 0.2).toFixed(2)), filter: 'url(#selectedGlow)' }));
+      // Planet body (grows slightly)
+      front.appendChild(mk('circle', { cx: pt.x.toFixed(1), cy: pt.y.toFixed(1), r: (10 + t * 3).toFixed(1), fill: color.fill }));
+
+    } else if (progress < 0.8) {
+      // ── Phase 2: launch streak toward star position ───────────────────────────
+      if (!anim.ringExitPt) {
+        // Snapshot the ring position at the moment of launch
+        anim.ringExitPt = ellipsePoint(angleOffset + ringRotation + Math.PI * 3, ringRx, ringRy);
+      }
+      const t = (progress - 0.5) / 0.3;
+      const ease = t * t * (3 - 2 * t); // smoothstep
+      const x = anim.ringExitPt.x + (targetPos.x - anim.ringExitPt.x) * ease;
+      const y = anim.ringExitPt.y + (targetPos.y - anim.ringExitPt.y) * ease;
+
+      // Comet tail pointing back along travel direction
+      const dx = targetPos.x - anim.ringExitPt.x, dy = targetPos.y - anim.ringExitPt.y;
+      const len = Math.sqrt(dx * dx + dy * dy) || 1;
+      const sl = (1 - ease) * 35;
+      front.appendChild(mk('line', {
+        x1: x.toFixed(1), y1: y.toFixed(1),
+        x2: (x - dx / len * sl).toFixed(1), y2: (y - dy / len * sl).toFixed(1),
+        stroke: color.fill, 'stroke-width': (4 - ease * 3).toFixed(1),
+        opacity: ((1 - ease) * 0.8).toFixed(3),
+      }));
+      // Planet shrinking as it flies
+      const r = 13 - ease * 10.5;
+      front.appendChild(mk('circle', { cx: x.toFixed(1), cy: y.toFixed(1), r: (r + 7).toFixed(1), fill: color.glow.replace('0.8', '0.2'), filter: 'url(#taskGlow)' }));
+      front.appendChild(mk('circle', { cx: x.toFixed(1), cy: y.toFixed(1), r: r.toFixed(1), fill: color.fill }));
+
+    } else {
+      // ── Phase 3: materialize as a star ───────────────────────────────────────
+      const t = (progress - 0.8) / 0.2;
+      const { x, y } = targetPos;
+
+      // Expanding ring shockwave
+      front.appendChild(mk('circle', { cx: x, cy: y, r: (t * 30).toFixed(1), fill: 'none', stroke: '#00ffcc', 'stroke-width': (3 - t * 2.5).toFixed(1), opacity: ((1 - t) * 0.7).toFixed(3) }));
+      // Inner implosion glow
+      front.appendChild(mk('circle', { cx: x, cy: y, r: (20 * (1 - t)).toFixed(1), fill: `rgba(0,255,204,${(0.25 * (1 - t)).toFixed(3)})`, filter: 'url(#selectedGlow)' }));
+      // Star rays crystallising
+      const rl = t * 11;
+      [[1, 0], [0, 1], [0.707, 0.707], [-0.707, 0.707]].forEach(([vx, vy]) => {
+        front.appendChild(mk('line', {
+          x1: (x - vx * rl).toFixed(1), y1: (y - vy * rl).toFixed(1),
+          x2: (x + vx * rl).toFixed(1), y2: (y + vy * rl).toFixed(1),
+          stroke: '#00ffcc', 'stroke-width': 1.3, opacity: t.toFixed(3),
+        }));
+      });
+      // Core snapping into place
+      front.appendChild(mk('circle', { cx: x, cy: y, r: 2.5, fill: '#00ffcc', opacity: t.toFixed(3) }));
+    }
   });
 }
 
@@ -247,9 +347,11 @@ export function startAnimLoop(onFrame) {
       ringRotation += diff * 0.08;
     }
     if (newTaskAnimating) { newTaskAnimating.progress += dt / 700; if (newTaskAnimating.progress >= 1) newTaskAnimating = null; }
+    completionAnimations.forEach(a => { a.progress += dt / 1600; });
+    completionAnimations = completionAnimations.filter(a => a.progress < 1);
     const es = document.getElementById('empty-svg-state');
     if (es) es.style.display = state.tasks.length === 0 ? 'block' : 'none';
-    if (state.currentView === 'saturn') { drawRing(ringRotation); drawCompletedStars(subTaskRotation); drawTasks(ringRotation); }
+    if (state.currentView === 'saturn') { drawRing(ringRotation); drawCompletedStars(subTaskRotation); drawTasks(ringRotation); drawCompletionAnimations(); }
     onFrame();
     requestAnimationFrame(animLoop);
   }

--- a/src/js/taskModal.js
+++ b/src/js/taskModal.js
@@ -1,5 +1,5 @@
 import { state, COLORS, TASK_COLORS, save } from './taskStore.js';
-import { ringRotation, setNewTaskAnimating } from './orbitRenderer.js';
+import { ringRotation, setNewTaskAnimating, addCompletionAnimation, cancelCompletionAnimation } from './orbitRenderer.js';
 
 // ─── SETTINGS ────────────────────────────────────────────────────────────────
 let settingsOpen = false;
@@ -267,6 +267,11 @@ export function deleteLastSubtask(parentIdx) {
 export function completeTask(idx) {
   if (idx < 0 || idx >= state.tasks.length) return;
   state.tasks[idx].done = !state.tasks[idx].done;
+  if (state.tasks[idx].done) {
+    if (state.currentView === 'saturn') addCompletionAnimation(idx, state.tasks.length);
+  } else {
+    cancelCompletionAnimation(state.tasks[idx].id);
+  }
   burst(innerWidth / 2, innerHeight * 0.5, state.tasks[idx].done ? '#00ffcc' : TASK_COLORS[idx % TASK_COLORS.length].fill, 12);
   showToast(state.tasks[idx].done ? 'Mission complete 🛸' : 'Mission reopened ○'); save();
   if (state.currentView === 'list') renderList();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,7 +48,7 @@ import '../styles/global.css';
     <div>
       <div class="s-title">Project</div>
       <a class="s-github" href="https://github.com/starship-droid/orbit-task-control" target="_blank" rel="noopener">starship-droid/orbit-task-control</a>
-      <div class="s-version">v0.5.2</div>
+      <div class="s-version">v0.5.3</div>
     </div>
   </div>
 </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,7 +48,7 @@ import '../styles/global.css';
     <div>
       <div class="s-title">Project</div>
       <a class="s-github" href="https://github.com/starship-droid/orbit-task-control" target="_blank" rel="noopener">starship-droid/orbit-task-control</a>
-      <div class="s-version">v0.5.1</div>
+      <div class="s-version">v0.5.2</div>
     </div>
   </div>
 </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,7 +48,7 @@ import '../styles/global.css';
     <div>
       <div class="s-title">Project</div>
       <a class="s-github" href="https://github.com/starship-droid/orbit-task-control" target="_blank" rel="noopener">starship-droid/orbit-task-control</a>
-      <div class="s-version">v0.4.2</div>
+      <div class="s-version">v0.5.0</div>
     </div>
   </div>
 </div>
@@ -105,6 +105,8 @@ import '../styles/global.css';
           </filter>
         </defs>
 
+        <!-- 0. Completed task stars (far background, behind everything) -->
+        <g id="completed-stars"></g>
         <!-- 1. Ring behind (top half) -->
         <g id="ring-behind" clip-path="url(#ringBehindClip)"></g>
         <!-- 2. Tasks behind saturn (very dim, drawn before the opaque body) -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,7 +48,7 @@ import '../styles/global.css';
     <div>
       <div class="s-title">Project</div>
       <a class="s-github" href="https://github.com/starship-droid/orbit-task-control" target="_blank" rel="noopener">starship-droid/orbit-task-control</a>
-      <div class="s-version">v0.5.0</div>
+      <div class="s-version">v0.5.1</div>
     </div>
   </div>
 </div>
@@ -183,6 +183,7 @@ import '../styles/global.css';
     <div class="shortcut"><span class="key">^N</span> Add subtask</div>
     <div class="shortcut"><span class="key">P</span> Cycle status</div>
     <div class="shortcut"><span class="key">I</span> Flag priority</div>
+    <div class="shortcut"><span class="key">C</span> Cycle stars</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Completed tasks leave the ring and appear as 4-pointed teal stars scattered in the background of the SVG
- Stars twinkle independently using a seeded sine function per task ID
- Stars glow brighter and grow larger when selected (task box still shows "MISSION COMPLETE")
- Star positions are deterministically placed outside the Saturn+ring exclusion zone via a seeded LCG hash
- Ring no longer snaps to bring completed tasks into view — it drifts freely
- Bumps version to v0.5.0 (minor bump for new user-visible feature)

## Test plan
- [ ] Complete a task (Space) — it should disappear from the ring and appear as a teal star
- [ ] Stars should twinkle at slightly different rates
- [ ] Navigate to a completed star with j/k — it should glow brighter, task box shows "MISSION COMPLETE"
- [ ] Un-complete a task (Space again) — it should return to the ring
- [ ] Multiple completed tasks — each appears at a distinct, stable position (same position on re-render)
- [ ] All tasks completed — ring is empty, all tasks are stars

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)